### PR TITLE
qWiz typemark link to home

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>qWiz</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ ReactDOM.render(
       <div className="row">
         <div className="col">
           <nav className="navbar-expand-lg navbar-dark bg-dark fixed-top">
-            <a className="navbar-brand text-weight-bold font-italic ml-1" href="qwiz.dev">qWiz
+            <a className="navbar-brand text-weight-bold font-italic ml-1" href="/">qWiz
             </a>
           </nav>
         </div>


### PR DESCRIPTION
qWiz typemark was linking to qwiz.dev/qwiz.dev, should be linking to '/'